### PR TITLE
Eliminate redudant R dependency from description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ License: GPL-2
 URL: https://github.com/kollerma/robustlmm
 LazyLoad: yes
 Depends:
-    R (>= 3.0.2),
     lme4 (>= 1.1-9),
     Matrix (>= 1.0-13),
     R (>= 3.2.0)


### PR DESCRIPTION
This caused a weird issue for a build script I have.  Don't feel obliged to merge, but just a heads up as this may later cause an issue on CRAN.